### PR TITLE
Fix to minor typo in config.coffee

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -38,7 +38,7 @@ exports.config =
           'vendor/scripts/bootstrap/bootstrap-popover.js',
           'vendor/scripts/bootstrap/bootstrap-scrollspy.js',
           'vendor/scripts/bootstrap/bootstrap-tab.js',
-          'vendor/scripts/bootstrap/bootstrap-typeahed.js'
+          'vendor/scripts/bootstrap/bootstrap-typeahead.js'
         ]
 
     stylesheets:


### PR DESCRIPTION
bootstrap-typeahead.js was misspelt
